### PR TITLE
fix (bucket versioning): removing deprecated parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,9 +8,12 @@ resource "aws_s3_bucket" "terraform" {
     Name        = "${var.s3_bucket_name}"
     Environment = "${var.env}"
   }
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "bucket_versioning" {
+  bucket = aws_s3_bucket.terraform.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 


### PR DESCRIPTION
I was looking for an example for remote backend using s3 and noticed that the bucket resource used in the repository is still using the deprecated "versioning" parameter for "aws_s3_bucket", so I added the new "aws_s3_bucket_versioning" resource.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning